### PR TITLE
Update default message and endpoint in ApplicationController

### DIFF
--- a/src/main/java/hu/cubix/cloud/api/ApplicationController.java
+++ b/src/main/java/hu/cubix/cloud/api/ApplicationController.java
@@ -20,7 +20,7 @@ public class ApplicationController {
         this.defaultMessage = defaultMessage;
     }
 
-    @GetMapping("/application/test")
+    @GetMapping("/cubix/test")
     public CubixResponse demoMessage(@RequestParam(required = false, name = "message") String message) {
         if (!StringUtils.hasText(message)) {
             message = defaultMessage;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-hw.message.default=default
+hw.message.default=https://www.youtube.com/watch?v=treHcOZsmgk

--- a/src/test/java/hu/cubix/cloud/api/ApplicationControllerTest.java
+++ b/src/test/java/hu/cubix/cloud/api/ApplicationControllerTest.java
@@ -11,7 +11,7 @@ class ApplicationControllerTest {
 
     @Test
     void defaultMessage() {
-        String defaultMessage = "default";
+        String defaultMessage = "https://www.youtube.com/watch?v=treHcOZsmgk";
         ApplicationController controller = new ApplicationController(defaultMessage);
         CubixResponse response = controller.demoMessage("");
         assertThat(response.time(), is(notNullValue()));

--- a/verify-image.sh
+++ b/verify-image.sh
@@ -2,7 +2,7 @@
 
 docker run -d --name test -p 8080:8080 ghcr.io/kpi-devopsgyak/cubix/1/homework/app:springboot > /dev/null
 sleep 10
-curl --fail http://localhost:8080/application/test
+curl --fail http://localhost:8080/cubix/test
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
   echo "Verification failed, here are the logs"


### PR DESCRIPTION
### Summary
This PR completes the second part of the homework by updating the REST endpoint and the default message logic in the application.

### Changes made
- Changed endpoint in `ApplicationController.java` from `/application/test` to `/cubix/test`
- Set new default message in `application.properties`:
  - `https://www.youtube.com/watch?v=treHcOZsmgk`
- Updated unit test in `ApplicationControllerTest.java` to reflect the new default message

### Validation
- Application builds with `./mvnw clean verify`
- App runs locally and responds correctly on `/cubix/test`
- Tests pass
- Manual curl request returns expected YouTube link

### Notes
- Follows feature branching strategy
- Targets my forked repository’s `main` branch
